### PR TITLE
Update for new RSS format

### DIFF
--- a/code/notebooks/reference_count.ipynb
+++ b/code/notebooks/reference_count.ipynb
@@ -63,7 +63,7 @@
    ],
    "source": [
     "# feed.get('items')[0].get('description')\n",
-    "descriptions = [ item.get('description') for item in feed.get('items') ]\n",
+    "descriptions = [ item.get('content')[0].get('value') for item in feed.get('items') ]\n",
     "print(f\"We found {len(descriptions)} descriptions.\")"
    ]
   },


### PR DESCRIPTION
RSS feed format for talkpython.fm podcast episodes must have changed, Pull a slightly different reference from each feedparser item.